### PR TITLE
Replace sass-rails with sassc-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'rails', '5.2.4.2'
 # Use postgres as the database for Active Record
 gem 'pg', '~> 1.2' # RAILS DOESN"T SUPPORT 1.0 AT THIS VERSION
 # Use SCSS for stylesheets
-gem 'sass-rails', '~> 5.0'
+gem 'sassc-rails', '~> 2.0'
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '>= 1.3.0'
 # Use CoffeeScript for .js.coffee assets and views

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,17 +152,14 @@ GEM
       ffi (~> 1.0)
     rdoc (6.2.1)
     ref (2.0.0)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (5.0.7)
-      railties (>= 4.0.0, < 6)
-      sass (~> 3.1)
-      sprockets (>= 2.8, < 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
-      tilt (>= 1.1, < 3)
+    sassc (2.2.1)
+      ffi (~> 1.9)
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     sdoc (1.1.0)
       rdoc (>= 5.0)
     spring (2.1.0)
@@ -209,7 +206,7 @@ DEPENDENCIES
   pg (~> 1.2)
   rails (= 5.2.4.2)
   rails_12factor
-  sass-rails (~> 5.0)
+  sassc-rails (~> 2.0)
   sdoc (~> 1.1.0)
   spring
   therubyracer


### PR DESCRIPTION
sass-rails v6.0.0 (#21) is just a shim for sassc-rails so better to use this gem instead.